### PR TITLE
Typo in  STLs/VORON2/README.md: tenstioner -> tensioner

### DIFF
--- a/STLs/VORON2/README.md
+++ b/STLs/VORON2/README.md
@@ -27,6 +27,6 @@ LCD
 
 Mobius
 * idler_arm
-* tenstioner_dial
+* tensioner_dial
 * jog_dial
 


### PR DESCRIPTION
Small typo