### PR TITLE
daveidmx V2.1 config features and fixes

### DIFF
--- a/Firmware/DuetWifi/V2.1/daveidmx/README.txt
+++ b/Firmware/DuetWifi/V2.1/daveidmx/README.txt
@@ -17,11 +17,14 @@ If you want to base your configuration off of mine, here are some files you'll w
 ***  "downcurrent" files are used for slow homing moves to reduce the impact of crash damage.
      You can opt out of the "downcurrent" profiles by uncommenting a couple lines as descibed in those files.
 **  /macros/filament/do_moves_for_*.g for bowden length
+**  /macros/heating/toolhead_*.g for your tool heater parameters.
+***  NOTE: If you add or rename the profile scripts, also update the script name inside the script itself. This is to support recovering the selection across reboots to make it easy to switch toolheads.
 **  /macros/homing/scripts/probe_zlevel.g for the leveling probe points
 **  /macros/homing/scripts/probe_x.g for the X dimension
 **  /macros/homing/scripts/probe_y.g for the Y dimension
 **  /macros/moveto/*.g based on your dimensions
 **  /macros/retraction/*.g for your retraction settings
+***  NOTE: If you add or rename the profile scripts, also update the script name inside the script itself. This is to support recovering the selection across reboots to make it easy to switch toolheads and retraction profiles.
 **  /macros/zprobe/use_i*.g for your inductive probe pins
 **  /macros/zprobe/use_m*.g for your mechanical switch pins, and to tune Z-height
 ***  NOTE: /macros/zprobe/use_mslow.g is the only place you need to tune your Z-height.
@@ -32,8 +35,15 @@ Bonus files for the test scripts:
 **  /macros/drive/*_torture.g
 
 Changes:
+
 * Default probe connectors have changed. The inductive probe has been moved from E0 to Zprobe to free up E0 for a filament detector.
 * Added bindings for filament sensors. (Disabled by default.)
 * Added bindings for chamber fan (enabled by default) and chamber thermistor and lights (disbled by default).
 * Changed drive parameters for V2.1.
 * Changed some other default settings to better match spec.
+
+* Fix some fan and temp bugs in the /macros/heating/preheat_*.g scripts.
+* Fix filament sensor configuration. (It wasn't turned on!)
+* Make toolhead heater and firmware retraction profile selections sticky across reboots to support changing toolheads.
+* Add retraction profiles for Volcano.
+* Increased motor default idle timeout to 24 hours.

--- a/Firmware/DuetWifi/V2.1/daveidmx/macros/drive/e_fullcurrent.g
+++ b/Firmware/DuetWifi/V2.1/daveidmx/macros/drive/e_fullcurrent.g
@@ -8,6 +8,6 @@
 
 M913 E100       ; restore motor current percentage to 100%
 M906 E1600      ; motor drive current
-M203 E3600      ; maximum speed (mm/min)
+M203 E6000      ; maximum speed (mm/min)
 M201 E3600      ; maximum acceleration (mm/min/s)
-M566 E1200      ; instantaneous speed change (mm/min)
+M566 E800       ; instantaneous speed change (mm/min)

--- a/Firmware/DuetWifi/V2.1/daveidmx/macros/heating/preheat_ABS.g
+++ b/Firmware/DuetWifi/V2.1/daveidmx/macros/heating/preheat_ABS.g
@@ -1,4 +1,4 @@
 T-1                     ; disable tools
-M140 S100               ; set bed temp
+M140 S110               ; set bed temp
 G10 P0 S235 R170        ; set tool temps
-M103 P3 S0              ; turn off chamber fan
+M106 P3 S0              ; turn off chamber fan

--- a/Firmware/DuetWifi/V2.1/daveidmx/macros/heating/preheat_PETG.g
+++ b/Firmware/DuetWifi/V2.1/daveidmx/macros/heating/preheat_PETG.g
@@ -1,4 +1,4 @@
 T-1                     ; disable tools
 M140 S85                ; set bed temp
 G10 P0 S235 R170        ; set tool temps
-M103 P3 S0              ; turn off chamber fan
+M106 P3 S0              ; turn off chamber fan

--- a/Firmware/DuetWifi/V2.1/daveidmx/macros/heating/preheat_PLA.g
+++ b/Firmware/DuetWifi/V2.1/daveidmx/macros/heating/preheat_PLA.g
@@ -1,4 +1,4 @@
 T-1                     ; disable tools
-M140 S110               ; set bed temp
-G10 P0 S200 R135        ; set tool temps
-M103 P3 S0.5            ; turn on chamber fan
+M140 S60                ; set bed temp
+G10 P0 S220 R150        ; set tool temps
+M106 P3 S0.5            ; turn on chamber fan

--- a/Firmware/DuetWifi/V2.1/daveidmx/macros/heating/preheat_PLA.g
+++ b/Firmware/DuetWifi/V2.1/daveidmx/macros/heating/preheat_PLA.g
@@ -1,4 +1,4 @@
 T-1                     ; disable tools
 M140 S60                ; set bed temp
-G10 P0 S220 R150        ; set tool temps
+G10 P0 S200 R150        ; set tool temps
 M106 P3 S0.5            ; turn on chamber fan

--- a/Firmware/DuetWifi/V2.1/daveidmx/macros/heating/toolhead_V6_copper_36W.g
+++ b/Firmware/DuetWifi/V2.1/daveidmx/macros/heating/toolhead_V6_copper_36W.g
@@ -1,1 +1,12 @@
+;; Run heater tune
+; M303 H1 S235
+;; Report heater parameters
+; M307 H1
+
+;; Set heater parameters
 M307 H1 A776.1 C297.4 D10.6 S1.00 V24.3 B0
+
+;; Save heater selection to be recovered on reboot
+M28 "/sys/restore_tool_heater.g"
+M98 P"/macros/heating/toolhead_V6_copper_36W.g"
+M29

--- a/Firmware/DuetWifi/V2.1/daveidmx/macros/heating/toolhead_Volcano_alu_36W.g
+++ b/Firmware/DuetWifi/V2.1/daveidmx/macros/heating/toolhead_Volcano_alu_36W.g
@@ -1,1 +1,12 @@
+;; Run heater tune
+; M303 H1 S235
+;; Report heater parameters
+; M307 H1
+
+;; Set heater parameters
 M307 H0 A271.6 C790.8 D1.6 S1.00 V24.3 B0
+
+;; Save heater selection to be recovered on reboot
+M28 "/sys/restore_tool_heater.g"
+M98 P"/macros/heating/toolhead_Volcano_alu_36W.g"
+M29

--- a/Firmware/DuetWifi/V2.1/daveidmx/macros/retraction/V6/pa_nozhop.g
+++ b/Firmware/DuetWifi/V2.1/daveidmx/macros/retraction/V6/pa_nozhop.g
@@ -1,0 +1,15 @@
+;; Pressure Advance can make seams really pretty.
+;; It's super noisy though, so I don't use it all the time.
+;; This file enables it.
+;;
+;;   https://duet3d.com/wiki/Pressure_advance
+;;
+;; *ADJUST* based on your retraction tuning WITH pressure advance
+
+M207 S3.0 R0.0 F3600 Z0.00
+M572 D0:1 S0.10
+
+;; Save retraction selection to be recovered on reboot
+M28 "/sys/restore_retraction.g"
+M98 P"/macros/retraction/v6/pa_nozhop.g"
+M29

--- a/Firmware/DuetWifi/V2.1/daveidmx/macros/retraction/V6/pa_zhop.g
+++ b/Firmware/DuetWifi/V2.1/daveidmx/macros/retraction/V6/pa_zhop.g
@@ -6,5 +6,10 @@
 ;;
 ;; *ADJUST* based on your retraction tuning WITH pressure advance
 
-M207 S3.0 R0.0 F3600 Z0.00
+M207 S3.0 R0.0 F3600 Z0.20
 M572 D0:1 S0.10
+
+;; Save retraction selection to be recovered on reboot
+M28 "/sys/restore_retraction.g"
+M98 P"/macros/retraction/v6/pa_zhop.g"
+M29

--- a/Firmware/DuetWifi/V2.1/daveidmx/macros/retraction/V6/quiet_nozhop.g
+++ b/Firmware/DuetWifi/V2.1/daveidmx/macros/retraction/V6/quiet_nozhop.g
@@ -1,0 +1,13 @@
+;; Pressure Advance can make seams really pretty.
+;; It's super noisy though, so I don't use it all the time.
+;; This file configures simple retraction instead.
+;;
+;; *ADJUST* based on your retraction tuning WITHOUT pressure advance
+
+M207 S4.0 R0.0 F3600 Z0.00
+M572 D0:1 S0.00
+
+;; Save retraction selection to be recovered on reboot
+M28 "/sys/restore_retraction.g"
+M98 P"/macros/retraction/v6/quiet_nozhop.g"
+M29

--- a/Firmware/DuetWifi/V2.1/daveidmx/macros/retraction/V6/quiet_zhop.g
+++ b/Firmware/DuetWifi/V2.1/daveidmx/macros/retraction/V6/quiet_zhop.g
@@ -4,5 +4,10 @@
 ;;
 ;; *ADJUST* based on your retraction tuning WITHOUT pressure advance
 
-M207 S4.0 R0.0 F3600 Z0.00
+M207 S4.0 R0.0 F3600 Z0.20
 M572 D0:1 S0.00
+
+;; Save retraction selection to be recovered on reboot
+M28 "/sys/restore_retraction.g"
+M98 P"/macros/retraction/v6/quiet_zhop.g"
+M29

--- a/Firmware/DuetWifi/V2.1/daveidmx/macros/retraction/Volcano/pa_nozhop.g
+++ b/Firmware/DuetWifi/V2.1/daveidmx/macros/retraction/Volcano/pa_nozhop.g
@@ -1,0 +1,15 @@
+;; Pressure Advance can make seams really pretty.
+;; It's super noisy though, so I don't use it all the time.
+;; This file enables it.
+;;
+;;   https://duet3d.com/wiki/Pressure_advance
+;;
+;; *ADJUST* based on your retraction tuning WITH pressure advance
+
+M207 S6.0 R0.0 F6000 Z0.00
+M572 D0:1 S0.2
+
+;; Save retraction selection to be recovered on reboot
+M28 "/sys/restore_retraction.g"
+M98 P"/macros/retraction/volcano/pa_nozhop.g"
+M29

--- a/Firmware/DuetWifi/V2.1/daveidmx/macros/retraction/Volcano/pa_zhop.g
+++ b/Firmware/DuetWifi/V2.1/daveidmx/macros/retraction/Volcano/pa_zhop.g
@@ -6,5 +6,10 @@
 ;;
 ;; *ADJUST* based on your retraction tuning WITH pressure advance
 
-M207 S3.0 R0.0 F3600 Z0.10
-M572 D0:1 S0.20
+M207 S6.0 R0.0 F6000 Z0.50
+M572 D0:1 S0.2
+
+;; Save retraction selection to be recovered on reboot
+M28 "/sys/restore_retraction.g"
+M98 P"/macros/retraction/volcano/pa_zhop.g"
+M29

--- a/Firmware/DuetWifi/V2.1/daveidmx/macros/retraction/Volcano/quiet_nozhop.g
+++ b/Firmware/DuetWifi/V2.1/daveidmx/macros/retraction/Volcano/quiet_nozhop.g
@@ -4,5 +4,10 @@
 ;;
 ;; *ADJUST* based on your retraction tuning WITHOUT pressure advance
 
-M207 S4.0 R0.0 F3600 Z0.20
+M207 S8.0 R0.0 F6000 Z0.00
 M572 D0:1 S0.00
+
+;; Save retraction selection to be recovered on reboot
+M28 "/sys/restore_retraction.g"
+M98 P"/macros/retraction/volcano/quiet_nozhop.g"
+M29

--- a/Firmware/DuetWifi/V2.1/daveidmx/macros/retraction/Volcano/quiet_zhop.g
+++ b/Firmware/DuetWifi/V2.1/daveidmx/macros/retraction/Volcano/quiet_zhop.g
@@ -1,0 +1,13 @@
+;; Pressure Advance can make seams really pretty.
+;; It's super noisy though, so I don't use it all the time.
+;; This file configures simple retraction instead.
+;;
+;; *ADJUST* based on your retraction tuning WITHOUT pressure advance
+
+M207 S8.0 R0.0 F6000 Z0.50
+M572 D0:1 S0.00
+
+;; Save retraction selection to be recovered on reboot
+M28 "/sys/restore_retraction.g"
+M98 P"/macros/retraction/volcano/quiet_zhop.g"
+M29

--- a/Firmware/DuetWifi/V2.1/daveidmx/sys/config.g
+++ b/Firmware/DuetWifi/V2.1/daveidmx/sys/config.g
@@ -57,11 +57,12 @@ M98 P"/macros/drive/e_fullcurrent.g"
 
 ;; firmware retraction -------------------------------------
 
-;; Choose one as your default:
-M98 P"/macros/retraction/quiet_nozhop.g
-;M98 P"/macros/retraction/quiet_zhop.g
-;M98 P"/macros/retraction/pa_nozhop.g"
-;M98 P"/macros/retraction/pa_zhop.g"
+;; To support changing toolheads and firmware retraction profiles,
+;; the firmware retraction parameters are stored in
+;; /macros/retraction/*.g
+;; Running those scripts will write back to the /sys/restore_retraction.g file.
+;; We run that file on startup, which enables retraction selection to be maintained across reboots.
+M98 P"/sys/restore_retraction.g"
 
 
 ;; thermal -------------------------------------------------
@@ -98,9 +99,10 @@ M106 P2 T35:55 H100:101:102 B1.0 L0.2 C"Electronics"
 M106 P3 S0 C"Chamber"
 ;M106 P8 B0 L0 S0.2 C"Lights"
 
-;; M303 H1 S235 ; run autotune
-;; M500 to save autotune results to config-override.g, then move the heater config lines from config-override.g here (or to a tool heater config macro).
-;; (Delete them from config-override.g, or you will be confused when changing this file doesn't work.)
+;; Bed autotune
+;; M303 H0 S100
+;; Show parameters
+;; M307 H0
 M307 H0 A271.6 C790.8 D1.6 S1.00 V24.3 B0
 
 ;; To support changing toolheads, the tool heater parameters are stored in

--- a/Firmware/DuetWifi/V2.1/daveidmx/sys/config.g
+++ b/Firmware/DuetWifi/V2.1/daveidmx/sys/config.g
@@ -112,11 +112,11 @@ M98 P"/macros/heating/toolhead_V6_copper_36W.g"
 M563 P0 D0 H1       ; bind tool 0 to drive and heater
 G10 P0 X0 Y0 Z0     ; tool offset
 G10 P0 S0 R0        ; tool active and standby temp
-;M591 D0 P2 C3       ; filament detector
+;M591 D0 P2 C3 S1    ; filament detector
 
 ;M563 P1 D1 H2      ; bind tool 1 to drive and heater
 ;G10 P1 X0 Y0 Z0    ; tool offset
 ;G10 P1 S0 R0       ; tool active and standby temp
-;M591 D1 P2 C4      ; filament detector
+;M591 D1 P2 C4 S1    ; filament detector
 
 T0                  ; activate tool 0

--- a/Firmware/DuetWifi/V2.1/daveidmx/sys/config.g
+++ b/Firmware/DuetWifi/V2.1/daveidmx/sys/config.g
@@ -103,8 +103,11 @@ M106 P3 S0 C"Chamber"
 ;; (Delete them from config-override.g, or you will be confused when changing this file doesn't work.)
 M307 H0 A271.6 C790.8 D1.6 S1.00 V24.3 B0
 
-M98 P"/macros/heating/toolhead_V6_copper_36W.g"
-;M98 P"/macros/heating/toolhead_Volcano_alu_36W.g"
+;; To support changing toolheads, the tool heater parameters are stored in
+;; /macros/heating/toolhead_*.g
+;; Running those scripts will write back to the /sys/restore_tool_heater.g file.
+;; We run that file on startup, which enables tool heater selection to be maintained across reboots.
+M98 P"/sys/restore_tool_heater.g"
 
 
 ;; tools ---------------------------------------------------

--- a/Firmware/DuetWifi/V2.1/daveidmx/sys/config.g
+++ b/Firmware/DuetWifi/V2.1/daveidmx/sys/config.g
@@ -44,8 +44,8 @@ M569 P8 S0      ; Z++ motor direction
 M569 P3 S0      ; E0 motor direction
 M569 P4 S0      ; E1 motor direction
 M569 P2 S0      ; E2 motor direction
-M84 S3600                           ; motor idle timeout
-M906 I50                            ; motor idle current percentage
+M84 S86400                          ; motor idle timeout
+M906 I0                             ; motor idle current percentage
 M350 X16 Y16 Z16 E16 I1             ; set microstepping
 M92 X80 Y80 Z400 E560               ; set microsteps per mm for 1.8-degree steppers
 

--- a/Firmware/DuetWifi/V2.1/daveidmx/sys/config.g
+++ b/Firmware/DuetWifi/V2.1/daveidmx/sys/config.g
@@ -94,7 +94,7 @@ M305 P102 S"Duex Drivers"               ; name and enable display of Duex steppe
 
 M106 P0 S0 ; C"Part" ; don't name part fan or it will show up twice in the UI
 M106 P1 T40:70 H1:2 C"Tool"
-M106 P2 T45:65 H100:101:102 C"Electronics"
+M106 P2 T35:55 H100:101:102 B1.0 L0.2 C"Electronics"
 M106 P3 S0 C"Chamber"
 ;M106 P8 B0 L0 S0.2 C"Lights"
 

--- a/Firmware/DuetWifi/V2.1/daveidmx/sys/restore_retraction.g
+++ b/Firmware/DuetWifi/V2.1/daveidmx/sys/restore_retraction.g
@@ -1,0 +1,1 @@
+M98 P"/macros/retraction/v6/quiet_zhop.g"

--- a/Firmware/DuetWifi/V2.1/daveidmx/sys/restore_tool_heater.g
+++ b/Firmware/DuetWifi/V2.1/daveidmx/sys/restore_tool_heater.g
@@ -1,0 +1,1 @@
+M98 P"/macros/heating/toolhead_V6_copper_36W.g"


### PR DESCRIPTION
* Fix some fan and temp bugs in the /macros/heating/preheat_*.g scripts.
* Fix filament sensor configuration. (It wasn't turned on!)
* Make toolhead heater and firmware retraction profile selections sticky across reboots to support changing toolheads.
* Add retraction profiles for Volcano.
* Increased motor default idle timeout to 24 hours.
