### PR TITLE
Remove M104 S0 from print_start

### DIFF
--- a/Firmware/Klipper/Voron 2/VORON2_stock_250_printer.cfg
+++ b/Firmware/Klipper/Voron 2/VORON2_stock_250_printer.cfg
@@ -335,7 +335,7 @@ gcode:
     G28							; home all axes
     G1 Z20 F3000					; move nozzle away from bed
     M117 Preheat (Print)
-    M104 S0						; turn off hotend while waiting for bed to get to temp
+   
 
 [gcode_macro PRINT_END]
 #   Use PRINT_END for the slicer ending script - please customise for your slicer of choice


### PR DESCRIPTION
Remove M104 S0 that turns off hotend from stock 250 config print_start macro 